### PR TITLE
HW2: SOLID and GRASP principles

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,8 +61,6 @@ func main() {
 		RateFetcher: rate.NewNBURateFetcher(),
 		UserRepo:    *models.NewUserRepository(db),
 	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	apiClient.Engine = server.NewEngine(ctx)
 
 	// Start cron job for notifications
 	cronSpec := os.Getenv("CRON_SPEC")
@@ -83,7 +81,7 @@ func main() {
 	})
 
 	// Start HTTP server
-	s := server.NewServer(apiClient.Config, apiClient.Engine)
+	s := server.NewServer(apiClient.Config, server.NewEngine(apiClient))
 	if err := s.ListenAndServe(); err != nil {
 		slog.Error("HTTP server error occurred", slog.Any("error", err))
 	}

--- a/main.go
+++ b/main.go
@@ -45,38 +45,44 @@ func main() {
 		os.Getenv("DEBUG") == "true",
 	)
 
-	mc := &mail.Client{Config: mailCfg.NewFromEnv()}
+	// Initialize database
 	db, err := database.New(dbCfg.NewFromEnv())
 	if err != nil {
 		slog.Error("failed to initialize database", slog.Any("error", err))
 		panic(err)
 	}
-	apiClient := server.Client{
-		Config:      serverCfg.NewFromEnv(),
-		RateFetcher: rate.NewNBURateFetcher(),
-		DB:          db,
-	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	apiClient.Engine = server.NewEngine(ctx)
-
-	if err := apiClient.DB.Migrate(&models.User{}); err != nil {
+	if err := db.Migrate(&models.User{}); err != nil {
 		slog.Error("failed to migrate database", slog.Any("error", err))
 		panic(err)
 	}
 
+	apiClient := server.Client{
+		Config:      serverCfg.NewFromEnv(),
+		RateFetcher: rate.NewNBURateFetcher(),
+		UserRepo:    *models.NewUserRepository(db),
+	}
+	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
+	apiClient.Engine = server.NewEngine(ctx)
+
+	// Start cron job for notifications
 	cronSpec := os.Getenv("CRON_SPEC")
 	if cronSpec == "" {
+		slog.Warn(
+			"CRON_SPEC is not set, using default value",
+			slog.Any("default", defaultCronSpec),
+		)
 		cronSpec = defaultCronSpec
 	}
 	notifier := notifications.NewUsersNotifier(
-		mc,
+		&mail.Client{Config: mailCfg.NewFromEnv()},
 		apiClient.RateFetcher,
-		models.NewUserRepository(apiClient.DB),
+		&apiClient.UserRepo,
 	)
 	StartCron(cronSpec, func() {
 		notifier.Notify(ctx)
 	})
 
+	// Start HTTP server
 	s := server.NewServer(apiClient.Config, apiClient.Engine)
 	if err := s.ListenAndServe(); err != nil {
 		slog.Error("HTTP server error occurred", slog.Any("error", err))

--- a/server/api.go
+++ b/server/api.go
@@ -12,9 +12,9 @@ type UserRepository interface {
 	Create(user *models.User) error
 }
 
-// GetRateWrapper is a handler that fetches the exchange rate between USD and UAH
+// NewGetRateHandler is a handler that fetches the exchange rate between USD and UAH
 // from a RateFetcher interface and returns it as a JSON response.
-func GetRateWrapper(rateFetcher RateFetcher) func(*gin.Context) {
+func NewGetRateHandler(rateFetcher RateFetcher) func(*gin.Context) {
 	return func(c *gin.Context) {
 		rate, err := rateFetcher.FetchRate("USD", "UAH")
 		if err != nil {
@@ -29,7 +29,7 @@ func GetRateWrapper(rateFetcher RateFetcher) func(*gin.Context) {
 // The email is passed as a POST parameter and is required.
 // If the user is already subscribed, returns a 409 Conflict status code.
 // If the subscription is successful, returns a 200 OK status code.
-func SubscribeUserWrapper(repo UserRepository) func(*gin.Context) {
+func NewSubscribeUserHandler(repo UserRepository) func(*gin.Context) {
 	return func(c *gin.Context) {
 		email := c.PostForm("email")
 		if email == "" {
@@ -58,7 +58,7 @@ func SubscribeUserWrapper(repo UserRepository) func(*gin.Context) {
 func NewEngine(client Client) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.GET("/rate", GetRateWrapper(client.RateFetcher))
-	r.POST("/subscribe", SubscribeUserWrapper(&client.UserRepo))
+	r.GET("/rate", NewGetRateHandler(client.RateFetcher))
+	r.POST("/subscribe", NewSubscribeUserHandler(&client.UserRepo))
 	return r
 }

--- a/server/api.go
+++ b/server/api.go
@@ -1,83 +1,64 @@
 package server
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/Hukyl/genesis-kma-school-entry/models"
-	"github.com/Hukyl/genesis-kma-school-entry/settings"
 	"github.com/gin-gonic/gin"
 )
 
-// wrapWithContext is a helper function that wraps a handler function
-// with a context and returns a gin.HandlerFunc.
-func wrapWithContext(ctx context.Context, fn func(context.Context, *gin.Context)) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		fn(ctx, c)
-	}
+type UserRepository interface {
+	Exists(user *models.User) (bool, error)
+	Create(user *models.User) error
 }
 
-// GetRate is a handler that fetches the exchange rate between USD and UAH
-// from the National Bank of Ukraine API and returns it as a JSON response.
-func GetRate(ctx context.Context, c *gin.Context) {
-	apiClient, ok := ctx.Value(settings.APIClientKey).(Client)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, "")
-		return
+// GetRateWrapper is a handler that fetches the exchange rate between USD and UAH
+// from a RateFetcher interface and returns it as a JSON response.
+func GetRateWrapper(rateFetcher RateFetcher) func(*gin.Context) {
+	return func(c *gin.Context) {
+		rate, err := rateFetcher.FetchRate("USD", "UAH")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, err.Error())
+			return
+		}
+		c.JSON(http.StatusOK, rate.Rate)
 	}
-	rateFetcher := apiClient.RateFetcher
-	rate, err := rateFetcher.FetchRate("USD", "UAH")
-	if err != nil {
-		c.JSON(http.StatusBadRequest, err.Error())
-		return
-	}
-	c.JSON(http.StatusOK, rate.Rate)
 }
 
 // SubscribeUser is a handler that subscribes a user by email.
 // The email is passed as a POST parameter and is required.
 // If the user is already subscribed, returns a 409 Conflict status code.
 // If the subscription is successful, returns a 200 OK status code.
-func SubscribeUser(ctx context.Context, c *gin.Context) {
-	email := c.PostForm("email")
-	if email == "" {
-		c.JSON(http.StatusBadRequest, "email is required")
-		return
+func SubscribeUserWrapper(repo UserRepository) func(*gin.Context) {
+	return func(c *gin.Context) {
+		email := c.PostForm("email")
+		if email == "" {
+			c.JSON(http.StatusBadRequest, "email is required")
+			return
+		}
+		user := &models.User{Email: email}
+		exists, err := repo.Exists(user)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, err.Error())
+			return
+		}
+		if exists {
+			c.JSON(http.StatusConflict, "")
+			return
+		}
+		err = repo.Create(user)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.JSON(http.StatusOK, "")
 	}
-	apiClient, ok := ctx.Value(settings.APIClientKey).(Client)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, "")
-		return
-	}
-	repo := apiClient.UserRepo
-	user := &models.User{Email: email}
-	exists, err := repo.Exists(user)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, err.Error())
-		return
-	}
-	if exists {
-		c.JSON(http.StatusConflict, "")
-		return
-	}
-	err = repo.Create(user)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, err.Error())
-		return
-	}
-	c.JSON(http.StatusOK, "")
 }
 
-func NewEngine(ctx context.Context) *gin.Engine {
+func NewEngine(client Client) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.GET(
-		"/rate",
-		wrapWithContext(ctx, GetRate),
-	)
-	r.POST(
-		"/subscribe",
-		wrapWithContext(ctx, SubscribeUser),
-	)
+	r.GET("/rate", GetRateWrapper(client.RateFetcher))
+	r.POST("/subscribe", SubscribeUserWrapper(&client.UserRepo))
 	return r
 }

--- a/server/api.go
+++ b/server/api.go
@@ -49,7 +49,7 @@ func SubscribeUser(ctx context.Context, c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, "")
 		return
 	}
-	repo := models.NewUserRepository(apiClient.DB)
+	repo := apiClient.UserRepo
 	user := &models.User{Email: email}
 	exists, err := repo.Exists(user)
 	if err != nil {

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -23,10 +23,7 @@ func TestGetRate(t *testing.T) {
 	})
 
 	// FIXME: tests should not depend on external services
-	req, err := http.NewRequest("GET", "/rate", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest(http.MethodGet, "/rate", nil)
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -41,10 +38,7 @@ func TestSubscribeUserNoEmail(t *testing.T) {
 		RateFetcher: rate.NewNBURateFetcher(),
 	})
 
-	req, err := http.NewRequest("POST", "/subscribe", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest(http.MethodPost, "/subscribe", nil)
 	rr := httptest.NewRecorder()
 	engine.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -57,10 +51,7 @@ func TestSubscribeUser(t *testing.T) {
 		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
 	})
 
-	req, err := http.NewRequest("POST", "/subscribe", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest(http.MethodPost, "/subscribe", nil)
 	req.PostForm = map[string][]string{
 		"email": {"example@gmail.com"},
 	}
@@ -76,10 +67,7 @@ func TestSubscribeUserAlreadySubscribed(t *testing.T) {
 		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
 	})
 
-	req, err := http.NewRequest("POST", "/subscribe", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	req := httptest.NewRequest(http.MethodPost, "/subscribe", nil)
 	req.PostForm = map[string][]string{
 		"email": {"example@gmail.com"},
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -76,7 +76,7 @@ func TestSubscribeUser(t *testing.T) {
 	apiClient := server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
-		DB:          database.SetUpTest(t, &models.User{}),
+		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
 	}
 	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
 	engine := server.NewEngine(ctx)
@@ -99,7 +99,7 @@ func TestSubscribeUserAlreadySubscribed(t *testing.T) {
 	apiClient := server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
-		DB:          database.SetUpTest(t, &models.User{}),
+		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
 	}
 	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
 	engine := server.NewEngine(ctx)

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,26 +16,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEmptyContext(t *testing.T) {
-	engine := server.NewEngine(context.Background())
-	req, err := http.NewRequest("GET", "/rate", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rr := httptest.NewRecorder()
-	engine.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-}
-
 func TestGetRate(t *testing.T) {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, settings.DebugKey, true)
-	apiClient := server.Client{
+	engine := server.NewEngine(server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
-	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	engine := server.NewEngine(ctx)
+	})
 
 	// FIXME: tests should not depend on external services
 	req, err := http.NewRequest("GET", "/rate", nil)
@@ -52,14 +36,10 @@ func TestGetRate(t *testing.T) {
 }
 
 func TestSubscribeUserNoEmail(t *testing.T) {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, settings.DebugKey, true)
-	apiClient := server.Client{
+	engine := server.NewEngine(server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
-	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	engine := server.NewEngine(ctx)
+	})
 
 	req, err := http.NewRequest("POST", "/subscribe", nil)
 	if err != nil {
@@ -71,15 +51,11 @@ func TestSubscribeUserNoEmail(t *testing.T) {
 }
 
 func TestSubscribeUser(t *testing.T) {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, settings.DebugKey, true)
-	apiClient := server.Client{
+	engine := server.NewEngine(server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
 		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
-	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	engine := server.NewEngine(ctx)
+	})
 
 	req, err := http.NewRequest("POST", "/subscribe", nil)
 	if err != nil {
@@ -94,15 +70,11 @@ func TestSubscribeUser(t *testing.T) {
 }
 
 func TestSubscribeUserAlreadySubscribed(t *testing.T) {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, settings.DebugKey, true)
-	apiClient := server.Client{
+	engine := server.NewEngine(server.Client{
 		Config:      serverCfg.NewFromEnv(),
 		RateFetcher: rate.NewNBURateFetcher(),
 		UserRepo:    *models.NewUserRepository(database.SetUpTest(t, &models.User{})),
-	}
-	ctx = context.WithValue(ctx, settings.APIClientKey, apiClient)
-	engine := server.NewEngine(ctx)
+	})
 
 	req, err := http.NewRequest("POST", "/subscribe", nil)
 	if err != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Hukyl/genesis-kma-school-entry/models"
 	"github.com/Hukyl/genesis-kma-school-entry/rate"
 	"github.com/Hukyl/genesis-kma-school-entry/server/config"
-	"github.com/gin-gonic/gin"
 )
 
 type RateFetcher interface {
@@ -14,6 +13,5 @@ type RateFetcher interface {
 type Client struct {
 	Config      config.Config
 	RateFetcher RateFetcher
-	Engine      *gin.Engine
 	UserRepo    models.UserRepository
 }

--- a/server/client.go
+++ b/server/client.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/Hukyl/genesis-kma-school-entry/database"
+	"github.com/Hukyl/genesis-kma-school-entry/models"
 	"github.com/Hukyl/genesis-kma-school-entry/rate"
 	"github.com/Hukyl/genesis-kma-school-entry/server/config"
 	"github.com/gin-gonic/gin"
@@ -15,5 +15,5 @@ type Client struct {
 	Config      config.Config
 	RateFetcher RateFetcher
 	Engine      *gin.Engine
-	DB          *database.DB
+	UserRepo    models.UserRepository
 }

--- a/server/notifications/notification.go
+++ b/server/notifications/notification.go
@@ -1,0 +1,29 @@
+package notifications
+
+import (
+	"fmt"
+
+	"github.com/Hukyl/genesis-kma-school-entry/rate"
+)
+
+// RateMessage is a message that contains the exchange rate between two currencies.
+type RateMessage struct {
+	rate rate.Rate
+}
+
+func (m RateMessage) Rate() rate.Rate {
+	return m.rate
+}
+
+func (m RateMessage) String() string {
+	return fmt.Sprintf(
+		"1 %s = %f %s",
+		m.rate.CurrencyFrom,
+		m.rate.Rate,
+		m.rate.CurrencyTo,
+	)
+}
+
+func NewRateMessage(rate rate.Rate) RateMessage {
+	return RateMessage{rate: rate}
+}

--- a/server/notifications/user_notifier.go
+++ b/server/notifications/user_notifier.go
@@ -2,7 +2,6 @@ package notifications
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/Hukyl/genesis-kma-school-entry/models"
@@ -53,8 +52,8 @@ func (n *UsersNotifier) Notify(ctx context.Context) {
 		slog.Any("userCount", len(users)),
 	)
 	for _, user := range users {
-		message := fmt.Sprintf("1 USD = %f UAH", rate.Rate)
-		if err := n.mailClient.SendEmail(ctx, user.Email, message); err != nil {
+		message := NewRateMessage(rate)
+		if err := n.mailClient.SendEmail(ctx, user.Email, message.String()); err != nil {
 			slog.Error(
 				"failed sending email",
 				slog.Any("error", err),

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -18,5 +18,4 @@ type ContextKey int
 
 const (
 	DebugKey ContextKey = iota
-	APIClientKey
 )


### PR DESCRIPTION
- Before creating the PR, most of the structs in packages have already been serving a single purpose (SRP), like `DB`, `UserRepository`, with only exception being `server.Client` which serves a purpose of collecting the dependencies between the project. 
- Some controllers were refactored to match DIP principle and use only the required interfaces. 
- Rate message formatting was delegated to a separate struct.